### PR TITLE
Enable AutoCompleteConfig feature

### DIFF
--- a/src/tensorrt_utils.cc
+++ b/src/tensorrt_utils.cc
@@ -49,6 +49,25 @@ ConvertTrtTypeToDataType(nvinfer1::DataType trt_type)
   return TRITONSERVER_TYPE_INVALID;
 }
 
+std::string
+ConvertTrtTypeToConfigDataType(nvinfer1::DataType trt_type)
+{
+  switch (trt_type) {
+    case nvinfer1::DataType::kFLOAT:
+      return "TYPE_FP32";
+    case nvinfer1::DataType::kHALF:
+      return "TYPE_FP16";
+    case nvinfer1::DataType::kINT8:
+      return "TYPE_INT8";
+    case nvinfer1::DataType::kINT32:
+      return "TYPE_INT32";
+    case nvinfer1::DataType::kBOOL:
+      return "TYPE_BOOL";
+  }
+
+  return "TYPE_INVALID";
+}
+
 bool
 UseTensorRTv2API(const nvinfer1::ICudaEngine* engine)
 {

--- a/src/tensorrt_utils.h
+++ b/src/tensorrt_utils.h
@@ -42,6 +42,8 @@ TRITONSERVER_Error* GetProfileIndex(
 
 TRITONSERVER_DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
 
+std::string ConvertTrtTypeToConfigDataType(nvinfer1::DataType trt_type);
+
 std::pair<bool, nvinfer1::DataType> ConvertDataTypeToTrtType(
     const TRITONSERVER_DataType& dtype);
 


### PR DESCRIPTION
Retains all the autofiller features.. However, it does not auto-detect plan file. The triton core requires the file to be named "model.plan" for AutoCompleteConfig to construct the full configuration. We can fix this with the move to clean-ups for autofiller in triton core. Added a comment for the same.