### PR TITLE
Fix the extra context index in the queue

### DIFF
--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -2906,6 +2906,7 @@ ModelInstanceState::RegisterContexts()
       context_queue_.Put(context_idx++);
     }
   }
+  next_context_idx_ = context_queue_.Get();
 }
 
 TRITONSERVER_Error*


### PR DESCRIPTION
This prevents the HtoD overwrites which causes inaccurate values. 