### PR TITLE
Initialize BackendInputCollector with coalesce input argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ backend that are then applied to all models that use the backend.
 
 ##### --backend-config=tensorrt,coalesce-request-input=\<boolean\>
 
-Instruct TensorRT to consider the request inputs as one contiguous buffer if
-their memory addresses align with each other.
+Instruct TensorRT to consider the requests' inputs with the same name as
+one contiguous buffer if their memory addresses align with each other.
+This option should only be enabled if all requests' input tensors are allocated
+from the same memory region. Default value is false.
 
 ## Build the TensorRT Backend
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ available in the main [server](https://github.com/triton-inference-server/server
 repo. If you don't find your answer there you can ask questions on the
 main Triton [issues page](https://github.com/triton-inference-server/server/issues).
 
+## Command-line Options
+
+The command-line options configure properties of the TensorRT
+backend that are then applied to all models that use the backend.
+
+##### --backend-config=tensorrt,coalesce-request-input=\<boolean\>
+
+Instruct TensorRT to consider the request inputs as one contiguous buffer if
+their memory addresses align with each other.
+
 ## Build the TensorRT Backend
 
 Appropriate version of TensorRT must be installed on the system. Check the support matrix to find the correct version of TensorRT to be installed.


### PR DESCRIPTION
TRT backend is an example of explicitly enable request input coalescent if requested via backend config. TRT backend is the only backend that require this optimization and will only apply the same change to other backends if requested.