### PR TITLE
fix deprecated-declarations error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo.")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo.")
 
+set(CMAKE_CXX_FLAGS "-Wno-error=deprecated-declarations -Wno-deprecated-declarations ")
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()


### PR DESCRIPTION
change CMakeLists.txt to fix issue described in issue: https://github.com/triton-inference-server/server/issues/3417

**To Reproduce**
```
git clone https://github.com/triton-inference-server/tensorrt_backend.git
cd tensorrt_backend
mkdir build
cd build
cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_ENABLE_STATS=OFF -DTRITON_TENSORRT_LIB_PATHS=/root/robertzhu/TensorRT-8.0.3.4/lib -DTRITON_TENSORRT_INCLUDE_PATHS=/root/robertzhu/TensorRT-8.0.3.4/include -DTRITON_BACKEND_REPO_TAG=r21.10 -DTRITON_CORE_REPO_TAG=r21.10 -DTRITON_COMMON_REPO_TAG=r21.10 ..
make install -j 10
```

**Expected behavior**
Shows the following error log
```
In file included from /root/robertzhu/tensorrt_backend/src/loader.h:28:0,
                 from /root/robertzhu/tensorrt_backend/src/loader.cc:27:
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:6066:101: error: 'IRNNv2Layer' is deprecated [-Werror=deprecated-declarations]
         ITensor& input, int32_t layerCount, int32_t hiddenSize, int32_t maxSeqLen, RNNOperation op) noexcept
                                                                                                     ^~~~~~~~
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:3086:22: note: declared here
 class TRT_DEPRECATED IRNNv2Layer : public ILayer
                      ^~~~~~~~~~~
In file included from /root/robertzhu/tensorrt_backend/src/logging.h:28:0,
                 from /root/robertzhu/tensorrt_backend/src/logging.cc:27:
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:6066:101: error: 'IRNNv2Layer' is deprecated [-Werror=deprecated-declarations]
         ITensor& input, int32_t layerCount, int32_t hiddenSize, int32_t maxSeqLen, RNNOperation op) noexcept
                                                                                                     ^~~~~~~~
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:3086:22: note: declared here
 class TRT_DEPRECATED IRNNv2Layer : public ILayer
                      ^~~~~~~~~~~
In file included from /root/robertzhu/tensorrt_backend/src/tensorrt_utils.h:29:0,
                 from /root/robertzhu/tensorrt_backend/src/tensorrt_utils.cc:27:
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:6066:101: error: 'IRNNv2Layer' is deprecated [-Werror=deprecated-declarations]
         ITensor& input, int32_t layerCount, int32_t hiddenSize, int32_t maxSeqLen, RNNOperation op) noexcept
                                                                                                     ^~~~~~~~
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:3086:22: note: declared here
 class TRT_DEPRECATED IRNNv2Layer : public ILayer
                      ^~~~~~~~~~~
In file included from /root/robertzhu/tensorrt_backend/src/loader.h:28:0,
                 from /root/robertzhu/tensorrt_backend/src/tensorrt.cc:28:
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:6066:101: error: 'IRNNv2Layer' is deprecated [-Werror=deprecated-declarations]
         ITensor& input, int32_t layerCount, int32_t hiddenSize, int32_t maxSeqLen, RNNOperation op) noexcept
                                                                                                     ^~~~~~~~
/root/robertzhu/TensorRT-8.0.3.4/include/NvInfer.h:3086:22: note: declared here
 class TRT_DEPRECATED IRNNv2Layer : public ILayer
                      ^~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/triton-tensorrt-backend.dir/src/loader.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /root/robertzhu/tensorrt_backend/build/_deps/repo-backend-src/include/triton/backend/backend_model.h:31:0,
                 from /root/robertzhu/tensorrt_backend/src/tensorrt_model.h:28,
                 from /root/robertzhu/tensorrt_backend/src/tensorrt.cc:30:
/root/robertzhu/tensorrt_backend/src/tensorrt.cc: In member function 'void triton::backend::tensorrt::ModelInstanceState::ProcessResponse()':
/root/robertzhu/tensorrt_backend/src/tensorrt.cc:2507:50: error: 'compute_end_ns' was not declared in this scope
               payload->compute_output_start_ns_, compute_end_ns),
                                                  ^
/root/robertzhu/tensorrt_backend/build/_deps/repo-backend-src/include/triton/backend/backend_common.h:62:38: note: in definition of macro 'LOG_IF_ERROR'
     TRITONSERVER_Error* lie_err__ = (X);                                       \
                                      ^
/root/robertzhu/tensorrt_backend/src/tensorrt.cc:2521:48: error: 'compute_end_ns' was not declared in this scope
             payload->compute_output_start_ns_, compute_end_ns),
                                                ^
/root/robertzhu/tensorrt_backend/build/_deps/repo-backend-src/include/triton/backend/backend_common.h:62:38: note: in definition of macro 'LOG_IF_ERROR'
     TRITONSERVER_Error* lie_err__ = (X);                                       \
                                      ^
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/triton-tensorrt-backend.dir/src/logging.cc.o] Error 1
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/triton-tensorrt-backend.dir/src/tensorrt_utils.cc.o] Error 1
/root/robertzhu/tensorrt_backend/src/tensorrt.cc: At global scope:
/root/robertzhu/tensorrt_backend/src/tensorrt.cc:119:1: error: 'void triton::backend::tensorrt::{anonymous}::TimestampCaptureCallback(void*)' defined but not used [-Werror=unused-function]
 TimestampCaptureCallback(void* data)
 ^~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/triton-tensorrt-backend.dir/src/tensorrt.cc.o] Error 1
make[1]: *** [CMakeFiles/triton-tensorrt-backend.dir/all] Error 2
make: *** [all] Error 2
```

**To Solve**
add `set(CMAKE_CXX_FLAGS "-Wno-error=deprecated-declarations -Wno-deprecated-declarations ")` in CMakeLists.txt