### PR TITLE
Handle implicit batch dimension for non batching models

### DIFF
--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -596,7 +596,7 @@ ModelState::AutoCompleteConfigHelper(const std::string& model_path)
   if (engine->hasImplicitBatchDimension()) {
     // If engine has implicit batch dimension then retrieve the value and exit
     max_batch_size = engine->getMaxBatchSize();
-    has_implicit_batch_dim = true;
+    has_implicit_batch_dim = (max_batch_size != 1);
   } else {
     // Assuming the first dimension to be batch dimension, until and unless
     // proven the batching is not supported.
@@ -614,7 +614,7 @@ ModelState::AutoCompleteConfigHelper(const std::string& model_path)
   } else if (
       (tensors_with_config_shape_cnt != 0) && (!config_batch_hint) &&
       (!has_implicit_batch_dim)) {
-    // if no hint for batching in config io
+    // if an explicit hint for non batching in config io
     LOG_MESSAGE(
         TRITONSERVER_LOG_WARN,
         (std::string("The specified dimensions in model config for ") + Name() +


### PR DESCRIPTION
According to the docs: 

> For an engine built from an [INetworkDefinition](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_network_definition.html) without an implicit batch dimension, this will always return 1.

Source:
https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_cuda_engine.html#a5c2185618a25cc94b588b3318be3b27d

This fixes `nobatch_*` model tests in likes of `L0_trt_reformat_free`.

@nv-kmcgill53  See how a lack of `config_batch_hint` in presence of non-zero `tensors_with_config_shape_cnt`  is treated as a case for batching being disabled.

