### PR TITLE
Use the SetModelConfig backend utility and parse the config again

### DIFF
--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -306,15 +306,7 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
       triton_model, &auto_complete_config));
   if (auto_complete_config) {
     RETURN_IF_ERROR((*state)->AutoCompleteConfig());
-
-    triton::common::TritonJson::WriteBuffer json_buffer;
-    (*state)->ModelConfig().Write(&json_buffer);
-
-    TRITONSERVER_Message* message;
-    RETURN_IF_ERROR(TRITONSERVER_MessageNewFromSerializedJson(
-        &message, json_buffer.Base(), json_buffer.Size()));
-    RETURN_IF_ERROR(TRITONBACKEND_ModelSetConfig(
-        triton_model, 1 /* config_version */, message));
+    RETURN_IF_ERROR((*state)->SetTensorRTModelConfig());
   }
 
   RETURN_IF_ERROR((*state)->ValidateModelConfig());

--- a/src/tensorrt_model.cc
+++ b/src/tensorrt_model.cc
@@ -58,6 +58,15 @@ TensorRTModel::TensorRTModel(TRITONBACKEND_Model* triton_model)
   ParseModelConfig();
 }
 
+TRITONSERVER_Error*
+TensorRTModel::SetTensorRTModelConfig()
+{
+  RETURN_IF_ERROR(SetModelConfig());
+  ParseModelConfig();
+
+  return nullptr;
+}
+
 void
 TensorRTModel::ParseModelConfig()
 {

--- a/src/tensorrt_model.h
+++ b/src/tensorrt_model.h
@@ -34,6 +34,8 @@ class TensorRTModel : public BackendModel {
   TensorRTModel(TRITONBACKEND_Model* triton_model);
   virtual ~TensorRTModel() = default;
 
+  TRITONSERVER_Error* SetTensorRTModelConfig();
+
   void ParseModelConfig();
 
   // The model configuration.


### PR DESCRIPTION
Uses the utility added by PR: https://github.com/triton-inference-server/backend/pull/64/files

After the update, we run the parsing on entire config just to be more future-proof in case backends add more auto-complete functionalities.