### PR TITLE
Fix L0_infer--cpu

### DIFF
--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -255,7 +255,7 @@ class ModelState : public TensorRTModel {
   TRITONSERVER_Error* ExtractBatchHintFromIOConfig(
       nvinfer1::ICudaEngine* engine, const std::string& tensor_name,
       const common::TritonJson::Value& dims, bool* config_batch_hint);
-  TRITONSERVER_Error* InstanceHasKindGPU(bool *has_instance_kind_gpu);
+  TRITONSERVER_Error* InstanceHasKindGPU(bool* has_instance_kind_gpu);
   TRITONSERVER_Error* GetRefIO(
       const bool is_input, nvinfer1::ICudaEngine* engine,
       triton::common::TritonJson::Value* ref_io);
@@ -308,9 +308,9 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
 
   // Server core already detects if a GPU is present and
   // corrects the instance groups before backend model is
-  // initialized. Since the TensorRT backend only works with 
-  // GPU instances, check if the model has a KIND_GPU 
-  // instance group. If KIND_GPU is not present, skip 
+  // initialized. Since the TensorRT backend only works with
+  // GPU instances, check if the model has a KIND_GPU
+  // instance group. If KIND_GPU is not present, skip
   // autocomplete as the model cannot be loaded.
   bool has_instance_kind_gpu = false;
   (*state)->InstanceHasKindGPU(&has_instance_kind_gpu);
@@ -831,14 +831,18 @@ ModelState::ExtractBatchHintFromIOConfig(
 }
 
 TRITONSERVER_Error*
-ModelState::InstanceHasKindGPU(bool *has_instance_kind_gpu) {
+ModelState::InstanceHasKindGPU(bool* has_instance_kind_gpu)
+{
   *has_instance_kind_gpu = false;
   triton::common::TritonJson::Value instance_groups(
-    ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
+      ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
   ModelConfig().Find("instance_group", &instance_groups);
-  for (size_t i = 0; i < instance_groups.ArraySize(); ++i) {
+
+  if (instance_groups.ArraySize() > 0) {
+    // TensorRT backend does not support KIND_CPU at all
+    // so only check the first instance group kind.
     triton::common::TritonJson::Value group;
-    RETURN_IF_ERROR(instance_groups.IndexAsObject(i, &group));
+    RETURN_IF_ERROR(instance_groups.IndexAsObject(0, &group));
 
     triton::common::TritonJson::Value kind;
     group.Find("kind", &kind);
@@ -846,11 +850,10 @@ ModelState::InstanceHasKindGPU(bool *has_instance_kind_gpu) {
     RETURN_IF_ERROR(kind.AsString(&kind_str));
     if (kind_str == "KIND_GPU") {
       *has_instance_kind_gpu = true;
-      break;
     }
   }
 
-  return nullptr; // success
+  return nullptr;  // success
 }
 
 

--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -255,6 +255,7 @@ class ModelState : public TensorRTModel {
   TRITONSERVER_Error* ExtractBatchHintFromIOConfig(
       nvinfer1::ICudaEngine* engine, const std::string& tensor_name,
       const common::TritonJson::Value& dims, bool* config_batch_hint);
+  TRITONSERVER_Error* InstanceHasKindGPU(bool *has_instance_kind_gpu);
   TRITONSERVER_Error* GetRefIO(
       const bool is_input, nvinfer1::ICudaEngine* engine,
       triton::common::TritonJson::Value* ref_io);
@@ -304,7 +305,17 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
   bool auto_complete_config = false;
   RETURN_IF_ERROR(TRITONBACKEND_ModelAutoCompleteConfig(
       triton_model, &auto_complete_config));
-  if (auto_complete_config) {
+
+  // Server core already detects if a GPU is present and
+  // corrects the instance groups before backend model is
+  // initialized. Since the TensorRT backend only works with 
+  // GPU instances, check if the model has a KIND_GPU 
+  // instance group. If KIND_GPU is not present, skip 
+  // autocomplete as the model cannot be loaded.
+  bool has_instance_kind_gpu = false;
+  (*state)->InstanceHasKindGPU(&has_instance_kind_gpu);
+
+  if (auto_complete_config && has_instance_kind_gpu) {
     RETURN_IF_ERROR((*state)->AutoCompleteConfig());
 
     triton::common::TritonJson::WriteBuffer json_buffer;
@@ -818,6 +829,30 @@ ModelState::ExtractBatchHintFromIOConfig(
   }
   return nullptr;
 }
+
+TRITONSERVER_Error*
+ModelState::InstanceHasKindGPU(bool *has_instance_kind_gpu) {
+  *has_instance_kind_gpu = false;
+  triton::common::TritonJson::Value instance_groups(
+    ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
+  ModelConfig().Find("instance_group", &instance_groups);
+  for (size_t i = 0; i < instance_groups.ArraySize(); ++i) {
+    triton::common::TritonJson::Value group;
+    RETURN_IF_ERROR(instance_groups.IndexAsObject(i, &group));
+
+    triton::common::TritonJson::Value kind;
+    group.Find("kind", &kind);
+    std::string kind_str;
+    RETURN_IF_ERROR(kind.AsString(&kind_str));
+    if (kind_str == "KIND_GPU") {
+      *has_instance_kind_gpu = true;
+      break;
+    }
+  }
+
+  return nullptr; // success
+}
+
 
 TRITONSERVER_Error*
 ModelState::GetRefIO(


### PR DESCRIPTION
Autocomplete attempts to load a model before model instances are created in core which causes a cuda runtime exception when no device is present. This PR fixes this problem by skipping autocomplete if there are no KIND_GPU instance groups in the model config. Triton core resolves the instance group kinds before the BackendModelInit function is called so we can rely on the current model config to give accurate information.