### PR TITLE
Remove Dlclosing of Plugins on Shutdown

### DIFF
--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -201,7 +201,6 @@ SupportsIntegratedZeroCopy(const int gpu_id, bool* zero_copy_support)
 struct BackendConfiguration {
   BackendConfiguration() : coalesce_request_input_(false) {}
   bool coalesce_request_input_;
-  std::vector<void*> library_handles_;
 };
 
 //
@@ -5521,8 +5520,6 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
           LOG_MESSAGE(TRITONSERVER_LOG_ERROR, TRITONSERVER_ErrorMessage(err));
           TRITONSERVER_ErrorDelete(err);
           err = nullptr;
-        } else {
-          lconfig->library_handles_.emplace_back(handle);
         }
 
         if (pos != std::string::npos) {
@@ -5561,19 +5558,7 @@ TRITONBACKEND_Finalize(TRITONBACKEND_Backend* backend)
 {
   void* vstate;
   RETURN_IF_ERROR(TRITONBACKEND_BackendState(backend, &vstate));
-  auto config = reinterpret_cast<BackendConfiguration*>(vstate);
-
-  // Close opened library handles.
-  for (auto& handle : config->library_handles_) {
-    auto err = CloseLibraryHandle(&handle);
-    if (err != nullptr) {
-      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, TRITONSERVER_ErrorMessage(err));
-      TRITONSERVER_ErrorDelete(err);
-      err = nullptr;
-    }
-  }
-
-  delete config;
+  delete reinterpret_cast<BackendConfiguration*>(vstate);
   return nullptr;  // success
 }
 


### PR DESCRIPTION
Dlclose is [not listed by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_04_03) as a safe function to call during signal handling, and thereby, "the behavior is undefined... if the signal handler calls any function defined in this standard other than one of the functions listed."

This ticket removes dlclose from the backend unloading. The plugin files should be closed and cleaned when the program/server shuts down, which is the only time backends are unloaded currently. This prevents potential race conditions that could cause the server to segfault (or have other unexpected behavior, e.g. deadlocking) during backend unloading.