### PR TITLE
Implement event timing using cudaEventElapsed

### DIFF
--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -399,7 +399,9 @@ class ModelInstanceState : public TensorRTModelInstance {
     cudaEvent_t output_ready_;
 
     // CUDA event for synchronizing the order of timestamp capture.
-    cudaEvent_t timestamp_signal_;
+    cudaEvent_t compute_output_start_;
+    cudaEvent_t compute_input_end_;
+    cudaEvent_t compute_input_start_;
   };
 
   // Use two sets of events each for current request and next request.


### PR DESCRIPTION
Old:

```
Avg request latency: 3160 usec (overhead 48 usec + queue 127 usec + compute input 222 usec + compute infer 2705 usec + compute output 56 usec)
```

New:

```
 Avg request latency: 3205 usec (overhead 59 usec + queue 153 usec + compute input 162 usec + compute infer 2665 usec + compute output 165 usec)
```

The actual copies for the model take ~100us for both inputs and outputs. I think the new measurements are closer to what is observed in the nsight trace for this model.