### PR TITLE
Remove input buffer reset. Increase the cuda event set

### DIFF
--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -527,9 +527,6 @@ class ModelInstanceState : public TensorRTModelInstance {
   // Whether zero copy is supported on this device
   bool zero_copy_support_;
 
-  // Whether to reset input binding buffers
-  bool reset_input_buffer_;
-
   // Whether the input collector will coalesce request inputs as if they form
   // one contiguous buffer when possible
   bool coalesce_request_input_;

--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -40,7 +40,7 @@
 namespace triton { namespace backend { namespace tensorrt {
 
 // Number of CUDA event set for each instance.
-static constexpr int EVENT_SET_COUNT = 2;
+static constexpr int EVENT_SET_COUNT = 3;
 
 //
 // BackendConfiguration

--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -40,6 +40,8 @@
 namespace triton { namespace backend { namespace tensorrt {
 
 // Number of CUDA event set for each instance.
+// We need three sets to avoid event overlaps between issue
+// and response threads. 
 static constexpr int EVENT_SET_COUNT = 3;
 
 //


### PR DESCRIPTION
When using eager_batching, the issue thread can override compute_input_start event. This may happen before a ProcessResponse thread has had a chance to retrieve the timestamp from the event. This happens because the ProcessResponse releases the semaphore for issue thread to proceed before retrieving the timestamp. Having 2 set of events help in normal scenario. But for eager batching we would need an additional set of events.

Otherwise we would run into errors like:

```
I0227 22:07:23.460482 275649 instance_state.cc:1243] elapsed time failed.: device not ready
```