### PR TITLE
Add more context to TensorRT error message

### DIFF
--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -1,4 +1,4 @@
-// Copyright 022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -1704,7 +1704,10 @@ ModelInstanceState::InitOptimizationProfiles()
       engine_->createExecutionContext());
   if (default_trt_context == nullptr) {
     return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL, "unable to create TensorRT context");
+        TRITONSERVER_ERROR_INTERNAL,
+        (std::string("unable to create TensorRT context: ") +
+         model_state_->GetTensorRTLogger().LastErrorMsg())
+            .c_str());
   }
 
   num_expected_bindings_ = total_bindings_ / total_profiles;
@@ -1745,7 +1748,10 @@ ModelInstanceState::InitOptimizationProfiles()
       res.first->second.context_.reset(engine_->createExecutionContext());
       if (res.first->second.context_ == nullptr) {
         return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INTERNAL, "unable to create TensorRT context");
+            TRITONSERVER_ERROR_INTERNAL,
+            (std::string("unable to create TensorRT context: ") +
+             model_state_->GetTensorRTLogger().LastErrorMsg())
+                .c_str());
       }
       if (!res.first->second.context_->setOptimizationProfileAsync(
               profile_index, stream_)) {

--- a/src/loader.h
+++ b/src/loader.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "logging.h"
 #include "triton/core/tritonserver.h"
 
 namespace triton { namespace backend { namespace tensorrt {
@@ -41,6 +42,7 @@ namespace triton { namespace backend { namespace tensorrt {
 /// \param plan_path The path to the model plan file.
 /// \param dla_core_id The DLA core to use for this runtime. Does not
 /// use DLA when set to -1.
+/// \param tensorrt_logger The logger to be used by this TensorRT plan.
 /// \param runtime Returns the IRuntime object, or nullptr if failed
 /// to create.
 /// \param engine Returns the ICudaEngine object, or nullptr if failed
@@ -49,6 +51,7 @@ namespace triton { namespace backend { namespace tensorrt {
 TRITONSERVER_Error* LoadPlan(
     const std::string& plan_path, const int64_t dla_core_id,
     std::shared_ptr<nvinfer1::IRuntime>* runtime,
-    std::shared_ptr<nvinfer1::ICudaEngine>* engine);
+    std::shared_ptr<nvinfer1::ICudaEngine>* engine,
+    TensorRTLogger* tensorrt_logger);
 
 }}}  // namespace triton::backend::tensorrt

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -35,6 +35,7 @@ TensorRTLogger::log(Severity severity, const char* msg) noexcept
 {
   switch (severity) {
     case Severity::kINTERNAL_ERROR:
+      RecordErrorMsg(msg);
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, msg);
       break;
     case Severity::kERROR:

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -38,7 +38,7 @@ TensorRTLogger::log(Severity severity, const char* msg) noexcept
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, msg);
       break;
     case Severity::kERROR:
-      StoreMsg(severity, msg);
+      RecordErrorMsg(msg);
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, msg);
       break;
     case Severity::kWARNING:
@@ -54,21 +54,16 @@ TensorRTLogger::log(Severity severity, const char* msg) noexcept
 }
 
 void
-TensorRTLogger::StoreMsg(Severity severity, const char* msg) noexcept
+TensorRTLogger::RecordErrorMsg(const char* msg) noexcept
 {
-  // Currently, only the 'Severity::kERROR' message is interested and this
-  // function will only be called when a 'Severity::kERROR' message arrives, but
-  // the interface is designed to be called by 'TensorRTLogger::log()' for any
-  // messages under any severity level, if the other messages become interested
-  // in the future.
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<std::mutex> lock(last_error_msg_mu_);
   last_error_msg_ = std::string(msg);
 }
 
 std::string
 TensorRTLogger::LastErrorMsg()
 {
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<std::mutex> lock(last_error_msg_mu_);
   return last_error_msg_;
 }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -34,10 +34,7 @@ void
 TensorRTLogger::log(Severity severity, const char* msg) noexcept
 {
   switch (severity) {
-    case Severity::kINTERNAL_ERROR:
-      RecordErrorMsg(msg);
-      LOG_MESSAGE(TRITONSERVER_LOG_ERROR, msg);
-      break;
+    case Severity::kINTERNAL_ERROR:  // fall-through to 'Severity::kERROR'
     case Severity::kERROR:
       RecordErrorMsg(msg);
       LOG_MESSAGE(TRITONSERVER_LOG_ERROR, msg);

--- a/src/logging.h
+++ b/src/logging.h
@@ -42,10 +42,10 @@ class TensorRTLogger : public nvinfer1::ILogger {
   std::string LastErrorMsg();
 
  private:
-  // Store messages logged by TensorRT
-  void StoreMsg(Severity severity, const char* msg) noexcept;
+  // Record error messages logged by TensorRT
+  void RecordErrorMsg(const char* msg) noexcept;
 
-  std::mutex mu_;  // serialize all state changing operations
+  std::mutex last_error_msg_mu_;  // Protect the last error message string.
   std::string last_error_msg_;
 };
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,13 +27,26 @@
 
 #include <NvInfer.h>
 
+#include <mutex>
+#include <string>
+
 namespace triton { namespace backend { namespace tensorrt {
 
 // Logger for TensorRT API
 class TensorRTLogger : public nvinfer1::ILogger {
+  // Called by TensorRT to log messages
   void log(Severity severity, const char* msg) noexcept override;
-};
 
-extern TensorRTLogger tensorrt_logger;
+ public:
+  // Return the last 'Severity::kERROR' message logged by TensorRT
+  std::string LastErrorMsg();
+
+ private:
+  // Store messages logged by TensorRT
+  void StoreMsg(Severity severity, const char* msg) noexcept;
+
+  std::mutex mu_;  // serialize all state changing operations
+  std::string last_error_msg_;
+};
 
 }}}  // namespace triton::backend::tensorrt

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -212,7 +212,8 @@ ModelState::CreateEngine(
 
     const bool new_runtime = (eit->second.first == nullptr);
     RETURN_IF_ERROR(LoadPlan(
-        model_path, dla_core_id, &eit->second.first, &eit->second.second));
+        model_path, dla_core_id, &eit->second.first, &eit->second.second,
+        &tensorrt_logger_));
     *engine = eit->second.second;
 
     if (new_runtime) {
@@ -388,8 +389,9 @@ ModelState::AutoCompleteConfigHelper(const std::string& model_path)
 {
   std::shared_ptr<nvinfer1::IRuntime> runtime;
   std::shared_ptr<nvinfer1::ICudaEngine> engine;
-  if (LoadPlan(model_path, -1 /* dla_core_id */, &runtime, &engine) !=
-      nullptr) {
+  if (LoadPlan(
+          model_path, -1 /* dla_core_id */, &runtime, &engine,
+          &tensorrt_logger_) != nullptr) {
     if (engine.get() != nullptr) {
       engine.reset();
     }

--- a/src/model_state.h
+++ b/src/model_state.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "logging.h"
 #include "tensorrt_model.h"
 #include "tensorrt_model_instance.h"
 
@@ -82,6 +83,8 @@ class ModelState : public TensorRTModel {
     return execution_arbitrator_->ExecutionState(device_id, instance);
   }
 
+  TensorRTLogger& GetTensorRTLogger() { return tensorrt_logger_; }
+
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
 
@@ -116,6 +119,9 @@ class ModelState : public TensorRTModel {
 
   // Parses the parameters in config
   TRITONSERVER_Error* ParseParameters();
+
+  // TensorRT logger for this model
+  TensorRTLogger tensorrt_logger_;
 
   // CUDA engine shared across all model instances using the same (or no) DLA
   // core on same GPU. The first element in the key pair is the GPU ID, the

--- a/src/tensorrt.cc
+++ b/src/tensorrt.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -168,6 +168,7 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   std::once_flag onceFlag;
   {
     std::call_once(onceFlag, [&success] {
+      TensorRTLogger tensorrt_logger;
       LOG_MESSAGE(TRITONSERVER_LOG_VERBOSE, "Registering TensorRT Plugins");
       success = initLibNvInferPlugins(&tensorrt_logger, "");
     });


### PR DESCRIPTION
Currently, the TensorRT error message are only printed to Triton error log, but not cannot be propagated back to the Triton client making the request. The PR adds the capability to store the last TensorRT error message from the model that generates the error, and propagates the error back to the Triton client, as a supplement for existing error messages that lack some context (i.e. "unable to create TensorRT runtime" and "unable to create TensorRT context")

Related PR: https://github.com/triton-inference-server/server/pull/5651
Closes triton-inference-server/server/issues/5304