### PR TITLE
Fix Segmentation Fault During TRT Model Initialization with CUDA Graphs Enabled

### DIFF
--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -3539,14 +3539,7 @@ TRTv1Interface::BuildCudaGraph(
     }
     // Use second set of buffers to capture cuda graph if
     // double-buffering
-    int buffer_binding_index;
-    if (instance_->num_copy_streams_ == 1) {
-      buffer_binding_index = 0;
-    } else {
-      buffer_binding_index =
-          std::min(instance_->num_copy_streams_ - 1, set_idx);
-    }
-
+    auto buffer_binding_index = set_idx % instance_->num_copy_streams_;
     cudaGraph_t graph;
     // Using cudaStreamCaptureModeThreadLocal mode to confine the graph
     // capture to this thread and avoid interference from other potentially
@@ -3710,12 +3703,8 @@ TRTv3Interface::BuildCudaGraph(
 
   for (int set_idx = 0; set_idx < EVENT_SET_COUNT; set_idx++) {
     cudaGraph_t graph;
-    if (instance_->num_copy_streams_ == 1) {
-      instance_->next_buffer_binding_set_ = 0;
-    } else {
-      instance_->next_buffer_binding_set_ =
-          std::min(instance_->num_copy_streams_ - 1, set_idx);
-    }
+    instance_->next_buffer_binding_set_ =
+        set_idx % instance_->num_copy_streams_;
     instance_->next_set_ = set_idx;
     // Using cudaStreamCaptureModeThreadLocal mode to confine the graph
     // capture to this thread and avoid interference from other potentially

--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -3539,7 +3539,14 @@ TRTv1Interface::BuildCudaGraph(
     }
     // Use second set of buffers to capture cuda graph if
     // double-buffering
-    auto buffer_binding_index = instance_->num_copy_streams_ == 1 ? 0 : set_idx;
+    int buffer_binding_index;
+    if (instance_->num_copy_streams_ == 1) {
+      buffer_binding_index = 0;
+    } else {
+      buffer_binding_index =
+          std::min(instance_->num_copy_streams_ - 1, set_idx);
+    }
+
     cudaGraph_t graph;
     // Using cudaStreamCaptureModeThreadLocal mode to confine the graph
     // capture to this thread and avoid interference from other potentially
@@ -3703,8 +3710,12 @@ TRTv3Interface::BuildCudaGraph(
 
   for (int set_idx = 0; set_idx < EVENT_SET_COUNT; set_idx++) {
     cudaGraph_t graph;
-    instance_->next_buffer_binding_set_ =
-        instance_->num_copy_streams_ == 1 ? 0 : set_idx;
+    if (instance_->num_copy_streams_ == 1) {
+      instance_->next_buffer_binding_set_ = 0;
+    } else {
+      instance_->next_buffer_binding_set_ =
+          std::min(instance_->num_copy_streams_ - 1, set_idx);
+    }
     instance_->next_set_ = set_idx;
     // Using cudaStreamCaptureModeThreadLocal mode to confine the graph
     // capture to this thread and avoid interference from other potentially


### PR DESCRIPTION
We have encountered a segmentation fault in the code at [tensorrt_backend/src/instance_state.cc#L4019](https://github.com/triton-inference-server/tensorrt_backend/blob/main/src/instance_state.cc#L4019) on using CUDA graphs. This is due to the `next_buffer_binding_set_` index going out of bounds.
`next_buffer_binding_set_` is updated at [tensorrt_backend/src/instance_state.cc#L3688](https://github.com/triton-inference-server/tensorrt_backend/blob/main/src/instance_state.cc#L3688) and uses `EVENT_SET_COUNT`.

This issue started occurring after increasing the `EVENT_SET_COUNT` from 2 to 3 in the [pull request](https://github.com/triton-inference-server/tensorrt_backend/pull/66/files#diff-d846a3687afe3645a6f657179a41075781a5f16cacc29ea7d1c8d474e0074f37R45) r23.03 release.
Restricting `next_buffer_binding_set_` to less than `num_copy_streams_` resolves the issue.

Backtrace:
```
Core was generated by `tritonserver --model-repository=./model_repo/ --log-verbose=2'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007fdaa05d6944 in triton::backend::tensorrt::IOBindingInfo::GetDeviceBuffer() const () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
[Current thread is 1 (Thread 0x7fda4ffff000 (LWP 457))]
(gdb) bt
#0  0x00007fdaa05d6944 in triton::backend::tensorrt::IOBindingInfo::GetDeviceBuffer() const () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#1  0x00007fdaa0585444 in triton::backend::tensorrt::TRTv3Interface::SetTensorAddress(nvinfer1::IExecutionContext*) ()
   from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#2  0x00007fdaa05b2caf in triton::backend::tensorrt::TRTv3Interface::BuildCudaGraph(triton::backend::tensorrt::TensorRTContext*, triton::backend::tensorrt::GraphSpec const&) () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#3  0x00007fdaa05be534 in triton::backend::tensorrt::ModelInstanceState::InitializeCudaGraph() () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#4  0x00007fdaa05bf2a3 in triton::backend::tensorrt::ModelInstanceState::Create(triton::backend::tensorrt::ModelState*, TRITONBACKEND_ModelInstance*, triton::backend::tensorrt::ModelInstanceState**) () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#5  0x00007fdaa055fd74 in TRITONBACKEND_ModelInstanceInitialize () from /opt/tritonserver/backends/tensorrt/libtriton_tensorrt.so
#6  0x00007fdaaa324086 in triton::core::TritonModelInstance::ConstructAndInitializeInstance(triton::core::TritonModel*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, triton::core::TritonModelInstance::Signature const&, TRITONSERVER_instancegroupkind_enum, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, inference::ModelRateLimiter const&, std::vector<triton::core::TritonModelInstance::SecondaryDevice, std::allocator<triton::core::TritonModelInstance::SecondaryDevice> > const&, std::shared_ptr<triton::core::TritonModelInstance>*) ()
   from /opt/tritonserver/bin/../lib/libtritonserver.so
#7  0x00007fdaaa3252c6 in triton::core::TritonModelInstance::CreateInstance(triton::core::TritonModel*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, triton::core::TritonModelInstance::Signature const&, TRITONSERVER_instancegroupkind_enum, int, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, inference::ModelRateLimiter const&, std::vector<triton::core::TritonModelInstance::SecondaryDevice, std::allocator<triton::core::TritonModelInstance::SecondaryDevice> > const&, std::shared_ptr<triton::core::TritonModelInstance>*) ()
   from /opt/tritonserver/bin/../lib/libtritonserver.so
```

The model configuration is as follows:
```
platform: "tensorrt_plan"

instance_group [
  {
    count: 2
    kind: KIND_GPU
    gpus: [0]
  }
]

optimization{
   graph: {
       level : 1
   },
   eager_batching : 1,
   cuda: {
       graphs: 1,
       graph_spec: [
    {
        batch_size: 167
    }
    ]
       busy_wait_events:1,
       output_copy_stream: 1
   }
}
```