### PR TITLE
fix: Add _10 version suffix to NVINFER_LIBRARY and NVINFER_PLUGIN_LIBRARY for TRT 10 Windows Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,8 @@ FOREACH(p ${TRITON_TENSORRT_LIB_PATHS})
     set(TRITON_TENSORRT_LDFLAGS ${TRITON_TENSORRT_LDFLAGS} "-L${p}")
 ENDFOREACH(p)
 
-# FIXME: TRT 10 appears to have differently named libraries with "_10" suffix
+# NOTE: TRT 10 for Windows added the version suffix to the library names. See the release notes:
+# https://docs.nvidia.com/deeplearning/tensorrt/release-notes/index.html#tensorrt-10
 find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10)
 find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10)
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,8 +216,9 @@ FOREACH(p ${TRITON_TENSORRT_LIB_PATHS})
     set(TRITON_TENSORRT_LDFLAGS ${TRITON_TENSORRT_LDFLAGS} "-L${p}")
 ENDFOREACH(p)
 
-find_library(NVINFER_LIBRARY NAMES nvinfer)
-find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin)
+# FIXME: TRT 10 appears to have differently named libraries with "_10" suffix
+find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10)
+find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10)
 target_link_libraries(
   triton-tensorrt-backend
   PRIVATE


### PR DESCRIPTION
Resolves this build issue on Windows:
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
NVINFER_LIBRARY
    linked by target "triton-tensorrt-backend" in directory C:/tmp/tritonbuild/tensorrt
NVINFER_PLUGIN_LIBRARY
    linked by target "triton-tensorrt-backend" in directory C:/tmp/tritonbuild/tensorrt
-- Generating done (0.2s)
CMake Warning:
  Manually-specified variables were not used by the project:
    TRITON_ENABLE_METRICS
    TRT_VERSION
CMake Generate step failed.  Build files cannot be regenerated correctly.
```