### PR TITLE
Fix tensorrt backend igpu build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,17 +122,6 @@ message(STATUS "TRT_VERSION envvar is $ENV{TRT_VERSION}")
 #
 if("$ENV{TRT_VERSION}" VERSION_LESS 10)
   set(SOURCE_DIR "src_trt8")
-else()
-  set(SOURCE_DIR "src")
-endif()
-
-
-#
-# Shared library implementing the Triton Backend API
-#
-configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
-
-if("$ENV{TRT_VERSION}" VERSION_LESS 10)
   add_library(
     triton-tensorrt-backend SHARED
     ${SOURCE_DIR}/tensorrt.cc
@@ -159,6 +148,7 @@ if("$ENV{TRT_VERSION}" VERSION_LESS 10)
     ${SOURCE_DIR}/io_binding_info.h
   )
 else()
+  set(SOURCE_DIR "src")
   add_library(
     triton-tensorrt-backend SHARED
     ${SOURCE_DIR}/tensorrt.cc
@@ -187,6 +177,11 @@ else()
     ${SOURCE_DIR}/io_binding_info.h
   )
 endif()
+
+#
+# Shared library implementing the Triton Backend API
+#
+configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
 
 add_library(
   TritonTensorRTBackend::triton-tensorrt-backend ALIAS triton-tensorrt-backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,6 @@ if("$ENV{TRT_VERSION}" VERSION_LESS 10)
     ${SOURCE_DIR}/instance_state.cc
     ${SOURCE_DIR}/tensorrt_model_instance.cc
     ${SOURCE_DIR}/tensorrt_model_instance.h
-    ${SOURCE_DIR}/shape_tensor.cc
-    ${SOURCE_DIR}/shape_tensor.h
     ${SOURCE_DIR}/tensorrt_utils.cc
     ${SOURCE_DIR}/tensorrt_utils.h
     ${SOURCE_DIR}/filesystem.h
@@ -170,6 +168,8 @@ else()
     ${SOURCE_DIR}/instance_state.cc
     ${SOURCE_DIR}/tensorrt_model_instance.cc
     ${SOURCE_DIR}/tensorrt_model_instance.h
+    ${SOURCE_DIR}/shape_tensor.cc
+    ${SOURCE_DIR}/shape_tensor.h
     ${SOURCE_DIR}/tensorrt_utils.cc
     ${SOURCE_DIR}/tensorrt_utils.h
     ${SOURCE_DIR}/filesystem.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,8 @@ if("$ENV{TRT_VERSION}" VERSION_LESS 10)
   configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
 
   target_include_directories(
-  triton-tensorrt-backend
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
+    triton-tensorrt-backend
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
   )
 else()
   set(SOURCE_DIR "src")
@@ -187,8 +187,8 @@ else()
   configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
 
   target_include_directories(
-  triton-tensorrt-backend
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
+    triton-tensorrt-backend
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,33 +132,61 @@ endif()
 #
 configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
 
-add_library(
-  triton-tensorrt-backend SHARED
-  ${SOURCE_DIR}/tensorrt.cc
-  ${SOURCE_DIR}/model_state.cc
-  ${SOURCE_DIR}/tensorrt_model.cc
-  ${SOURCE_DIR}/tensorrt_model.h
-  ${SOURCE_DIR}/instance_state.cc
-  ${SOURCE_DIR}/tensorrt_model_instance.cc
-  ${SOURCE_DIR}/tensorrt_model_instance.h
-  ${SOURCE_DIR}/shape_tensor.cc
-  ${SOURCE_DIR}/shape_tensor.h
-  ${SOURCE_DIR}/tensorrt_utils.cc
-  ${SOURCE_DIR}/tensorrt_utils.h
-  ${SOURCE_DIR}/filesystem.h
-  ${SOURCE_DIR}/filesystem.cc
-  ${SOURCE_DIR}/semaphore.h
-  ${SOURCE_DIR}/shared_library.h
-  ${SOURCE_DIR}/shared_library.cc
-  ${SOURCE_DIR}/loader.cc
-  ${SOURCE_DIR}/loader.h
-  ${SOURCE_DIR}/logging.cc
-  ${SOURCE_DIR}/logging.h
-  ${SOURCE_DIR}/output_allocator.cc
-  ${SOURCE_DIR}/output_allocator.h
-  ${SOURCE_DIR}/io_binding_info.cc
-  ${SOURCE_DIR}/io_binding_info.h
-)
+if("$ENV{TRT_VERSION}" VERSION_LESS 10)
+  add_library(
+    triton-tensorrt-backend SHARED
+    ${SOURCE_DIR}/tensorrt.cc
+    ${SOURCE_DIR}/model_state.cc
+    ${SOURCE_DIR}/tensorrt_model.cc
+    ${SOURCE_DIR}/tensorrt_model.h
+    ${SOURCE_DIR}/instance_state.cc
+    ${SOURCE_DIR}/tensorrt_model_instance.cc
+    ${SOURCE_DIR}/tensorrt_model_instance.h
+    ${SOURCE_DIR}/shape_tensor.cc
+    ${SOURCE_DIR}/shape_tensor.h
+    ${SOURCE_DIR}/tensorrt_utils.cc
+    ${SOURCE_DIR}/tensorrt_utils.h
+    ${SOURCE_DIR}/filesystem.h
+    ${SOURCE_DIR}/filesystem.cc
+    ${SOURCE_DIR}/semaphore.h
+    ${SOURCE_DIR}/shared_library.h
+    ${SOURCE_DIR}/shared_library.cc
+    ${SOURCE_DIR}/loader.cc
+    ${SOURCE_DIR}/loader.h
+    ${SOURCE_DIR}/logging.cc
+    ${SOURCE_DIR}/logging.h
+    ${SOURCE_DIR}/output_allocator.cc
+    ${SOURCE_DIR}/output_allocator.h
+    ${SOURCE_DIR}/io_binding_info.cc
+    ${SOURCE_DIR}/io_binding_info.h
+  )
+else()
+  add_library(
+    triton-tensorrt-backend SHARED
+    ${SOURCE_DIR}/tensorrt.cc
+    ${SOURCE_DIR}/model_state.cc
+    ${SOURCE_DIR}/tensorrt_model.cc
+    ${SOURCE_DIR}/tensorrt_model.h
+    ${SOURCE_DIR}/instance_state.cc
+    ${SOURCE_DIR}/tensorrt_model_instance.cc
+    ${SOURCE_DIR}/tensorrt_model_instance.h
+    ${SOURCE_DIR}/tensorrt_utils.cc
+    ${SOURCE_DIR}/tensorrt_utils.h
+    ${SOURCE_DIR}/filesystem.h
+    ${SOURCE_DIR}/filesystem.cc
+    ${SOURCE_DIR}/semaphore.h
+    ${SOURCE_DIR}/shared_library.h
+    ${SOURCE_DIR}/shared_library.cc
+    ${SOURCE_DIR}/loader.cc
+    ${SOURCE_DIR}/loader.h
+    ${SOURCE_DIR}/logging.cc
+    ${SOURCE_DIR}/logging.h
+    ${SOURCE_DIR}/output_allocator.cc
+    ${SOURCE_DIR}/output_allocator.h
+    ${SOURCE_DIR}/io_binding_info.cc
+    ${SOURCE_DIR}/io_binding_info.h
+  )
+endif()
 
 add_library(
   TritonTensorRTBackend::triton-tensorrt-backend ALIAS triton-tensorrt-backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,13 @@ if("$ENV{TRT_VERSION}" VERSION_LESS 10)
     ${SOURCE_DIR}/io_binding_info.cc
     ${SOURCE_DIR}/io_binding_info.h
   )
+  # Shared library implementing the Triton Backend API
+  configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
+
+  target_include_directories(
+  triton-tensorrt-backend
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
+  )
 else()
   set(SOURCE_DIR "src")
   add_library(
@@ -176,20 +183,17 @@ else()
     ${SOURCE_DIR}/io_binding_info.cc
     ${SOURCE_DIR}/io_binding_info.h
   )
-endif()
+  # Shared library implementing the Triton Backend API
+  configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
 
-#
-# Shared library implementing the Triton Backend API
-#
-configure_file(${SOURCE_DIR}/libtriton_tensorrt.ldscript libtriton_tensorrt.ldscript COPYONLY)
+  target_include_directories(
+  triton-tensorrt-backend
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
+  )
+endif()
 
 add_library(
   TritonTensorRTBackend::triton-tensorrt-backend ALIAS triton-tensorrt-backend
-)
-
-target_include_directories(
-  triton-tensorrt-backend
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_DIR}
 )
 
 target_include_directories(


### PR DESCRIPTION
`shape_tensor.cc` and `shape_tensor.h` need to be included only for TRT v10 and above.