### PR TITLE
Fix shape and reformat free tensor handling in the input byte size check

### DIFF
--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -1909,10 +1909,8 @@ ModelInstanceState::ValidateIOHelper(
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,
             (type + " '" + io_name + "' for model '" + model_state_->Name() +
-             "' uses a non-linear IO format, but the model configuration "
-             "does not specify it as such. Set "
-             "'is_non_linear_format_io' to true for " +
-             type + " '" + io_name + "'.")
+             "' uses a non-linear IO format, but 'is_non_linear_format_io' is "
+             "incorrectly set to false in the model configuration.")
                 .c_str());
       }
     } else {
@@ -1924,9 +1922,7 @@ ModelInstanceState::ValidateIOHelper(
             TRITONSERVER_ERROR_INTERNAL,
             (type + " '" + io_name + "' for model '" + model_state_->Name() +
              "' uses a linear IO format, but 'is_non_linear_format_io' is "
-             "incorrectly set to true. Set "
-             "'is_non_linear_format_io' to false for " +
-             type + " '" + io_name + "'.")
+             "incorrectly set to true in the model configuration.")
                 .c_str());
       }
     }

--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -778,9 +778,9 @@ ModelInstanceState::Run(
               payload_->responses_,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_INVALID_ARG,
-                  (std::string("tensor for input '") + name +
-                   "' expected byte size is " +
-                   std::to_string(total_byte_size) + ", got " +
+                  (std::string("input byte size mismatch for input '") + name +
+                   "'" + " for model '" + model_state_->Name() +
+                   "'. Expected " + std::to_string(total_byte_size) + ", got " +
                    std::to_string(req_data_byte_size))
                       .c_str()),
               "failed to run TRT inference");

--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -295,7 +295,9 @@ class ModelInstanceState : public TensorRTModelInstance {
   TRITONSERVER_Error* ValidateIO();
   TRITONSERVER_Error* ValidateIOHelper(
       common::TritonJson::Value& ios,
-      const std::set<std::string>& allowed_shape_tensors, const bool is_input);
+      const std::set<std::string>& allowed_shape_tensors,
+      const std::set<std::string>& allowed_reformat_free_tensors,
+      const bool is_input);
 
   TRITONSERVER_Error* InitIOBindingBuffers();
   TRITONSERVER_Error* InitializeConfigShapeInputBindings(

--- a/src/instance_state.h
+++ b/src/instance_state.h
@@ -296,7 +296,7 @@ class ModelInstanceState : public TensorRTModelInstance {
   TRITONSERVER_Error* ValidateIOHelper(
       common::TritonJson::Value& ios,
       const std::set<std::string>& allowed_shape_tensors,
-      const std::set<std::string>& allowed_reformat_free_tensors,
+      const std::set<std::string>& allowed_non_linear_format_io,
       const bool is_input);
 
   TRITONSERVER_Error* InitIOBindingBuffers();

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -912,7 +912,7 @@ ModelState::FixIO(
                   TRITONSERVER_ERROR_INVALID_ARG,
                   (std::string("'") + io_name +
                    "' uses a linear IO format, but 'is_non_linear_format_io' "
-                   "is incorrectly set to true.")
+                   "is incorrectly set to true in the model configuration.")
                       .c_str());
             } else if (!non_linear_format_io_val && is_non_linear_format_io) {
               RETURN_IF_ERROR(

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -754,7 +754,10 @@ ModelState::GetRefIO(
   for (int i = 0; i < num_io_tensors; ++i) {
     const std::string& tensor_name = engine->getIOTensorName(i);
     nvinfer1::Dims dims = engine->getTensorShape(tensor_name.c_str());
-    bool is_shape_binding = engine->isShapeInferenceIO(tensor_name.c_str());
+    bool is_shape_tensor = engine->isShapeInferenceIO(tensor_name.c_str());
+    bool is_reformat_free_tensor =
+        (engine->getTensorFormat(tensor_name.c_str()) !=
+         nvinfer1::TensorFormat::kLINEAR);
     if ((is_input && (!IsInput(engine, tensor_name))) ||
         ((!is_input) && (IsInput(engine, tensor_name)))) {
       continue;
@@ -766,8 +769,10 @@ ModelState::GetRefIO(
     RETURN_IF_ERROR(io.AddString(
         "data_type", ConvertTrtTypeToConfigDataType(
                          engine->getTensorDataType(tensor_name.c_str()))));
-    RETURN_IF_ERROR(InitIODims(engine, dims, is_shape_binding, &io));
-    RETURN_IF_ERROR(io.AddBool("is_shape_tensor", is_shape_binding));
+    RETURN_IF_ERROR(InitIODims(engine, dims, is_shape_tensor, &io));
+    RETURN_IF_ERROR(io.AddBool("is_shape_tensor", is_shape_tensor));
+    RETURN_IF_ERROR(
+        io.AddBool("is_reformat_free_tensor", is_reformat_free_tensor));
 
     RETURN_IF_ERROR(ref_io->Append(std::move(io)));
   }
@@ -777,13 +782,13 @@ ModelState::GetRefIO(
 
 TRITONSERVER_Error*
 ModelState::InitIODims(
-    nvinfer1::ICudaEngine* engine, nvinfer1::Dims& dims, bool is_shape_binding,
+    nvinfer1::ICudaEngine* engine, nvinfer1::Dims& dims, bool is_shape_tensor,
     triton::common::TritonJson::Value* io)
 {
   bool skip_first = (MaxBatchSize() != 0);
   triton::common::TritonJson::Value config_dims(
       ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
-  if (!is_shape_binding) {
+  if (!is_shape_tensor) {
     for (int didx = (skip_first ? 1 : 0); didx < dims.nbDims; ++didx) {
       RETURN_IF_ERROR(config_dims.AppendInt(dims.d[didx]));
     }
@@ -871,8 +876,7 @@ ModelState::FixIO(
           }
 
           // Check if the IO is a shape tensor.
-          bool is_shape_tensor = false;
-          is_shape_tensor = engine->isShapeInferenceIO(io_name.c_str());
+          bool is_shape_tensor = engine->isShapeInferenceIO(io_name.c_str());
 
           common::TritonJson::Value shape_tensor;
           if (mutable_io.Find("is_shape_tensor", &shape_tensor)) {
@@ -885,15 +889,37 @@ ModelState::FixIO(
                    "' is incorrectly specified as a shape tensor.")
                       .c_str());
             } else if (!shape_tensor_val && is_shape_tensor) {
-              return TRITONSERVER_ErrorNew(
-                  TRITONSERVER_ERROR_INVALID_ARG,
-                  (std::string("'") + io_name +
-                   "' is incorrectly specified as an execution tensor.")
-                      .c_str());
+              RETURN_IF_ERROR(shape_tensor.SetBool(is_shape_tensor));
             }
           } else {
             RETURN_IF_ERROR(
                 mutable_io.AddBool("is_shape_tensor", is_shape_tensor));
+          }
+
+          // Check if the IO is a reformat free tensor.
+          bool is_reformat_free_tensor =
+              (engine->getTensorFormat(io_name.c_str()) !=
+               nvinfer1::TensorFormat::kLINEAR);
+
+          common::TritonJson::Value reformat_free_tensor;
+          if (mutable_io.Find(
+                  "is_reformat_free_tensor", &reformat_free_tensor)) {
+            bool reformat_free_tensor_val = false;
+            RETURN_IF_ERROR(
+                reformat_free_tensor.AsBool(&reformat_free_tensor_val));
+            if (reformat_free_tensor_val && (!is_reformat_free_tensor)) {
+              return TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("'") + io_name +
+                   "' is incorrectly specified as a reformat free tensor.")
+                      .c_str());
+            } else if (!reformat_free_tensor_val && is_reformat_free_tensor) {
+              RETURN_IF_ERROR(
+                  reformat_free_tensor.SetBool(is_reformat_free_tensor));
+            }
+          } else {
+            RETURN_IF_ERROR(mutable_io.AddBool(
+                "is_reformat_free_tensor", is_reformat_free_tensor));
           }
           break;
         }

--- a/src/model_state.h
+++ b/src/model_state.h
@@ -109,8 +109,8 @@ class ModelState : public TensorRTModel {
       const bool is_input, nvinfer1::ICudaEngine* engine,
       triton::common::TritonJson::Value* ref_io);
   TRITONSERVER_Error* InitIODims(
-      nvinfer1::ICudaEngine* engine, nvinfer1::Dims& dims,
-      bool is_shape_binding, triton::common::TritonJson::Value* io);
+      nvinfer1::ICudaEngine* engine, nvinfer1::Dims& dims, bool is_shape_tensor,
+      triton::common::TritonJson::Value* io);
   TRITONSERVER_Error* FixIO(
       nvinfer1::ICudaEngine* engine,
       triton::common::TritonJson::Value& reference_ios,

--- a/src/tensorrt_utils.cc
+++ b/src/tensorrt_utils.cc
@@ -501,26 +501,26 @@ TensorFormatToString(const nvinfer1::TensorFormat& io_format)
       return "CHW2";
     case nvinfer1::TensorFormat::kCHW4:
       return "CHW4";
-    case nvinfer1::TensorFormat::kHWC8:
-      return "HWC8";
     case nvinfer1::TensorFormat::kCHW16:
       return "CHW16";
     case nvinfer1::TensorFormat::kCHW32:
       return "CHW32";
+    case nvinfer1::TensorFormat::kDHWC:
+      return "DHWC";
     case nvinfer1::TensorFormat::kDHWC8:
       return "DHWC8";
-    case nvinfer1::TensorFormat::kCDHW32:
-      return "CDHW32";
     case nvinfer1::TensorFormat::kHWC:
       return "HWC";
+    case nvinfer1::TensorFormat::kHWC8:
+      return "HWC8";
+    case nvinfer1::TensorFormat::kHWC16:
+      return "HWC16";
+    case nvinfer1::TensorFormat::kCDHW32:
+      return "CDHW32";
     case nvinfer1::TensorFormat::kDLA_LINEAR:
       return "DLA_LINEAR";
     case nvinfer1::TensorFormat::kDLA_HWC4:
       return "DLA_HWC4";
-    case nvinfer1::TensorFormat::kHWC16:
-      return "HWC16";
-    case nvinfer1::TensorFormat::kDHWC:
-      return "DHWC";
     default:
       return "INVALID";
   }

--- a/src/tensorrt_utils.cc
+++ b/src/tensorrt_utils.cc
@@ -491,6 +491,39 @@ DimsJsonToString(common::TritonJson::Value& dims)
   return ShapeToString(dims_vec);
 }
 
+const std::string
+TensorFormatToString(const nvinfer1::TensorFormat& io_format)
+{
+  switch (io_format) {
+    case nvinfer1::TensorFormat::kLINEAR:
+      return "LINEAR";
+    case nvinfer1::TensorFormat::kCHW2:
+      return "CHW2";
+    case nvinfer1::TensorFormat::kCHW4:
+      return "CHW4";
+    case nvinfer1::TensorFormat::kHWC8:
+      return "HWC8";
+    case nvinfer1::TensorFormat::kCHW16:
+      return "CHW16";
+    case nvinfer1::TensorFormat::kDHWC8:
+      return "DHWC8";
+    case nvinfer1::TensorFormat::kCDHW32:
+      return "CDHW32";
+    case nvinfer1::TensorFormat::kHWC:
+      return "HWC";
+    case nvinfer1::TensorFormat::kDLA_LINEAR:
+      return "DLA_LINEAR";
+    case nvinfer1::TensorFormat::kDLA_HWC4:
+      return "DLA_HWC4";
+    case nvinfer1::TensorFormat::kHWC16:
+      return "HWC16";
+    case nvinfer1::TensorFormat::kDHWC:
+      return "DHWC";
+    default:
+      return "INVALID";
+  }
+}
+
 TRITONSERVER_Error*
 SupportsIntegratedZeroCopy(const int gpu_id, bool* zero_copy_support)
 {

--- a/src/tensorrt_utils.cc
+++ b/src/tensorrt_utils.cc
@@ -505,6 +505,8 @@ TensorFormatToString(const nvinfer1::TensorFormat& io_format)
       return "HWC8";
     case nvinfer1::TensorFormat::kCHW16:
       return "CHW16";
+    case nvinfer1::TensorFormat::kCHW32:
+      return "CHW32";
     case nvinfer1::TensorFormat::kDHWC8:
       return "DHWC8";
     case nvinfer1::TensorFormat::kCDHW32:

--- a/src/tensorrt_utils.cc
+++ b/src/tensorrt_utils.cc
@@ -522,7 +522,7 @@ TensorFormatToString(const nvinfer1::TensorFormat& io_format)
     case nvinfer1::TensorFormat::kDLA_HWC4:
       return "DLA_HWC4";
     default:
-      return "INVALID";
+      return "UNKNOWN";
   }
 }
 

--- a/src/tensorrt_utils.h
+++ b/src/tensorrt_utils.h
@@ -108,6 +108,8 @@ const std::string DimsDebugString(const nvinfer1::Dims& dims);
 
 const std::string DimsJsonToString(common::TritonJson::Value& dims);
 
+const std::string TensorFormatToString(const nvinfer1::TensorFormat& io_format);
+
 TRITONSERVER_Error* SupportsIntegratedZeroCopy(
     const int gpu_id, bool* zero_copy_support);
 


### PR DESCRIPTION
- Added support for the `is_non_linear_format_io` flag in the model configuration to identify whether input/output tensors use a non-linear IO format.
- Modified the auto-complete configuration to correctly initialize the `is_shape_tensor` and `is_non_linear_format_io` flags.
- For tensors using the non-linear IO format (reformat-free tensors), the backend now validates the input byte size.