### PR TITLE
build: RHEL8 TensorRT Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,8 +247,8 @@ ENDFOREACH(p)
 
 # NOTE: TRT 10 for Windows added the version suffix to the library names. See the release notes:
 # https://docs.nvidia.com/deeplearning/tensorrt/release-notes/index.html#tensorrt-10
-find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10)
-find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10)
+find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10 HINTS "/usr/local/cuda/targets/x86_64-linux/lib")
+find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10 HINTS "/usr/local/cuda/targets/x86_64-linux/lib")
 target_link_libraries(
   triton-tensorrt-backend
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,8 +247,8 @@ ENDFOREACH(p)
 
 # NOTE: TRT 10 for Windows added the version suffix to the library names. See the release notes:
 # https://docs.nvidia.com/deeplearning/tensorrt/release-notes/index.html#tensorrt-10
-find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10 HINTS "/usr/local/cuda/targets/x86_64-linux/lib")
-find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10 HINTS "/usr/local/cuda/targets/x86_64-linux/lib")
+find_library(NVINFER_LIBRARY NAMES nvinfer nvinfer_10 PATHS "/usr/local/cuda/targets/x86_64-linux/lib")
+find_library(NVINFER_PLUGIN_LIBRARY NAMES nvinfer_plugin nvinfer_plugin_10 PATHS "/usr/local/cuda/targets/x86_64-linux/lib")
 target_link_libraries(
   triton-tensorrt-backend
   PRIVATE


### PR DESCRIPTION
**Goal:** Support the TensorRT Backend on RHEL8 systems. Only change necessary here was assistance to find the `libnvinfer*` libraries.

Server Changes: https://github.com/triton-inference-server/server/pull/7568
PyTorch Backend: https://github.com/triton-inference-server/pytorch_backend/pull/137
TensorFlow: https://github.com/triton-inference-server/tensorflow_backend/pull/105
ORT Backend: https://github.com/triton-inference-server/onnxruntime_backend/pull/266

