### PR TITLE
Build Updates for Ubuntu24.04 (#102)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ target_compile_features(triton-tensorrt-backend PRIVATE cxx_std_${TRITON_MIN_CXX
 target_compile_options(
   triton-tensorrt-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-    -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Werror -Wno-deprecated-declarations>
+    -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Wno-deprecated-declarations>
   $<$<CXX_COMPILER_ID:MSVC>:/Wall /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor>
 )
 


### PR DESCRIPTION
* skip warning errors

* Revert "skip warning errors"

This reverts commit 97456d081b1d6ed0445d6e0a52c85142e8549918.

* disable maybe-uninitialize warning errors

* remove werror