### PR TITLE
feat: Support for allocating GPU memory based on the selected profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,21 @@ but the listed CMake argument can be used to override.
 * triton-inference-server/backend: -DTRITON_BACKEND_REPO_TAG=[tag]
 * triton-inference-server/core: -DTRITON_CORE_REPO_TAG=[tag]
 * triton-inference-server/common: -DTRITON_COMMON_REPO_TAG=[tag]
+
+## Parameters
+
+Triton exposes some flags to control the execution mode of the TensorRT models through
+the Parameters section of the model's `config.pbtxt` file.
+
+### execution_context_allocation_strategy
+
+Different memory allocation behaviors for IExecutionContext. IExecutionContext requires a block of device memory for internal activation tensors during inference. The user can let the execution context manage the memory in various ways. Current options are "STATIC" (default) and "ON_PROFILE_CHANGE".
+
+```
+parameters: {
+  key: "execution_context_allocation_strategy"
+  value: {
+    string_value: "STATIC"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ the Parameters section of the model's `config.pbtxt` file.
 
 Different memory allocation behaviors for IExecutionContext. IExecutionContext requires a block of device memory for internal activation tensors during inference. The user can let the execution context manage the memory in various ways. Current options are "STATIC" (default) and "ON_PROFILE_CHANGE".
 
+* "STATIC": Default static allocation with the maximum size across all profiles.
+* "ON_PROFILE_CHANGE": Reallocate for a profile when it's selected.
+
 ```
 parameters: {
   key: "execution_context_allocation_strategy"

--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -1698,7 +1698,7 @@ ModelInstanceState::InitOptimizationProfiles()
   // context per engine, in order to set the specified profile_index,
   // another context is created and the previous context is destroyed.
   std::shared_ptr<nvinfer1::IExecutionContext> default_trt_context(
-      engine_->createExecutionContext());
+      engine_->createExecutionContext(model_state_->AllocationStrategy()));
   if (default_trt_context == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INTERNAL,
@@ -1739,7 +1739,7 @@ ModelInstanceState::InitOptimizationProfiles()
     if (profile_index == 0) {
       res.first->second.context_ = std::move(default_trt_context);
     } else {
-      res.first->second.context_.reset(engine_->createExecutionContext());
+      res.first->second.context_.reset(engine_->createExecutionContext(model_state_->AllocationStrategy()));
       if (res.first->second.context_ == nullptr) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,

--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -1693,10 +1693,6 @@ ModelInstanceState::InitIOIndexMap()
 TRITONSERVER_Error*
 ModelInstanceState::InitOptimizationProfiles()
 {
-  // TRT sets the optimization profile index to be 0 implicitly with
-  // the first context creation. As currently triton supports one
-  // context per engine, in order to set the specified profile_index,
-  // another context is created and the previous context is destroyed.
   std::vector<std::pair<std::string, int>> profile_name_index;
   // No optimization profile is set for this TensorRT plan
   if (ProfileNames().empty()) {

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -142,7 +142,8 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
 }
 
 ModelState::ModelState(TRITONBACKEND_Model* triton_model)
-    : TensorRTModel(triton_model), engine_sharing_(true)
+    : TensorRTModel(triton_model), engine_sharing_(true),
+      alloc_strategy_(nvinfer1::ExecutionContextAllocationStrategy::kSTATIC)
 {
   // Obtain backend configuration
   TRITONBACKEND_Backend* backend;
@@ -288,29 +289,41 @@ ModelState::ValidateModelConfig()
 TRITONSERVER_Error*
 ModelState::ParseParameters()
 {
-  std::string exec_alloc_strategy_str = "STATIC";
-
-  common::TritonJson::Value params;
-  if (ModelConfig().Find("parameters", &params)) {
-      LOG_MESSAGE(TRITONSERVER_LOG_VERBOSE, "'parameters' field found in model configuration.");
-      common::TritonJson::Value strategy_param;
-      if (params.Find("execution_context_allocation_strategy", &strategy_param)) {
-          LOG_MESSAGE(TRITONSERVER_LOG_VERBOSE, "'execution_context_allocation_strategy' field found in model configuration in 'parameters' field.");
-          std::string allocation_strategy_str;
-          RETURN_IF_ERROR(strategy_param.MemberAsString("string_value", &exec_alloc_strategy_str));
+  triton::common::TritonJson::Value params;
+  bool status = ModelConfig().Find("parameters", &params);
+  if (status) {
+    // If 'allocation_strategy' is not present in 'parameters',
+    // will use the default strategy "STATIC".
+    std::string alloc_strategy;
+    TRITONSERVER_Error* err =
+        GetParameterValue(params, "allocation_strategy", &alloc_strategy);
+    if (err != nullptr) {
+      if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
+        return err;
+      } else {
+        TRITONSERVER_ErrorDelete(err);
       }
-      if (exec_alloc_strategy_str == "STATIC") {
-        exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
-      } else if (exec_alloc_strategy_str == "ON_PROFILE_CHANGE") {
-        exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kON_PROFILE_CHANGE;
+    } else {
+      // allocation_strategy is present in model config parameters
+      if (alloc_strategy == "STATIC") {
+        alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
+      } else if (alloc_strategy == "ON_PROFILE_CHANGE") {
+        alloc_strategy_ =
+            nvinfer1::ExecutionContextAllocationStrategy::kON_PROFILE_CHANGE;
       } else {
         return TRITONSERVER_ErrorNew(
-                TRITONSERVER_ERROR_INVALID_ARG,
-                ("Invalid value for execution_context_allocation_strategy field: " + exec_alloc_strategy_str).c_str());
+            TRITONSERVER_ERROR_INVALID_ARG,
+            ("Invalid value for 'allocation_strategy': '" + alloc_strategy +
+             "' for model instance '" + Name() +
+             "'. Supported values are 'STATIC' and 'ON_PROFILE_CHANGE'.")
+                .c_str());
       }
-      LOG_MESSAGE(TRITONSERVER_LOG_VERBOSE, ("Selected Execution Context Allocation Strategy: " + exec_alloc_strategy_str).c_str());
-  } else {
-      LOG_MESSAGE(TRITONSERVER_LOG_VERBOSE, "'parameters' field NOT found in model configuration.");
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
+          ("'allocation_strategy' set to '" + alloc_strategy +
+           "' for model instance '" + Name() + "'")
+              .c_str());
+    }
   }
   return nullptr;  // success
 }

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -292,7 +292,7 @@ ModelState::ParseParameters()
   triton::common::TritonJson::Value params;
   bool status = ModelConfig().Find("parameters", &params);
   if (status) {
-    // If 'allocation_strategy' is not present in 'parameters',
+    // If 'execution_context_allocation_strategy' is not present in 'parameters',
     // will use the default strategy "STATIC".
     std::string alloc_strategy;
     TRITONSERVER_Error* err =

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -292,11 +292,11 @@ ModelState::ParseParameters()
   triton::common::TritonJson::Value params;
   bool status = ModelConfig().Find("parameters", &params);
   if (status) {
-    // If 'execution_context_allocation_strategy' is not present in 'parameters',
-    // will use the default strategy "STATIC".
+    // If 'execution_context_allocation_strategy' is not present in
+    // 'parameters', will use the default strategy "STATIC".
     std::string alloc_strategy;
-    TRITONSERVER_Error* err =
-        GetParameterValue(params, "execution_context_allocation_strategy", &alloc_strategy);
+    TRITONSERVER_Error* err = GetParameterValue(
+        params, "execution_context_allocation_strategy", &alloc_strategy);
     if (err != nullptr) {
       if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
         return err;
@@ -304,7 +304,8 @@ ModelState::ParseParameters()
         TRITONSERVER_ErrorDelete(err);
       }
     } else {
-      // 'execution_context_allocation_strategy' is present in model config parameters.
+      // 'execution_context_allocation_strategy' is present in model config
+      // parameters.
       if (alloc_strategy == "STATIC") {
         alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
       } else if (alloc_strategy == "ON_PROFILE_CHANGE") {
@@ -313,8 +314,8 @@ ModelState::ParseParameters()
       } else {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
-            ("Invalid value for 'execution_context_allocation_strategy': '" + alloc_strategy +
-             "' for model instance '" + Name() +
+            ("Invalid value for 'execution_context_allocation_strategy': '" +
+             alloc_strategy + "' for model instance '" + Name() +
              "'. Supported values are 'STATIC' and 'ON_PROFILE_CHANGE'.")
                 .c_str());
       }

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -296,7 +296,7 @@ ModelState::ParseParameters()
     // will use the default strategy "STATIC".
     std::string alloc_strategy;
     TRITONSERVER_Error* err =
-        GetParameterValue(params, "allocation_strategy", &alloc_strategy);
+        GetParameterValue(params, "execution_context_allocation_strategy", &alloc_strategy);
     if (err != nullptr) {
       if (TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_NOT_FOUND) {
         return err;
@@ -313,14 +313,14 @@ ModelState::ParseParameters()
       } else {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
-            ("Invalid value for 'allocation_strategy': '" + alloc_strategy +
+            ("Invalid value for 'execution_context_allocation_strategy': '" + alloc_strategy +
              "' for model instance '" + Name() +
              "'. Supported values are 'STATIC' and 'ON_PROFILE_CHANGE'.")
                 .c_str());
       }
       LOG_MESSAGE(
           TRITONSERVER_LOG_INFO,
-          ("'allocation_strategy' set to '" + alloc_strategy +
+          ("'execution_context_allocation_strategy' set to '" + alloc_strategy +
            "' for model instance '" + Name() + "'")
               .c_str());
     }

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -304,7 +304,7 @@ ModelState::ParseParameters()
         TRITONSERVER_ErrorDelete(err);
       }
     } else {
-      // allocation_strategy is present in model config parameters
+      // 'execution_context_allocation_strategy' is present in model config parameters.
       if (alloc_strategy == "STATIC") {
         alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
       } else if (alloc_strategy == "ON_PROFILE_CHANGE") {

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -303,8 +303,6 @@ ModelState::ParseParameters()
         exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
       } else if (exec_alloc_strategy_str == "ON_PROFILE_CHANGE") {
         exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kON_PROFILE_CHANGE;
-      } else if (exec_alloc_strategy_str == "USER_MANAGED") {
-        exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kUSER_MANAGED;
       } else {
         return TRITONSERVER_ErrorNew(
                 TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/model_state.h
+++ b/src/model_state.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -90,7 +90,7 @@ class ModelState : public TensorRTModel {
 
   nvinfer1::ExecutionContextAllocationStrategy AllocationStrategy() const
   {
-      return exec_alloc_strategy_;
+    return alloc_strategy_;
   }
 
  private:
@@ -146,7 +146,7 @@ class ModelState : public TensorRTModel {
   // Whether the backend should support version-compatible TensorRT models.
   static inline bool is_version_compatible_{false};
 
-  nvinfer1::ExecutionContextAllocationStrategy exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
+  nvinfer1::ExecutionContextAllocationStrategy alloc_strategy_;
 };
 
 

--- a/src/model_state.h
+++ b/src/model_state.h
@@ -88,6 +88,11 @@ class ModelState : public TensorRTModel {
 
   TensorRTLogger& GetTensorRTLogger() { return tensorrt_logger_; }
 
+  nvinfer1::ExecutionContextAllocationStrategy AllocationStrategy() const
+  {
+      return exec_alloc_strategy_;
+  }
+
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
 
@@ -140,6 +145,8 @@ class ModelState : public TensorRTModel {
 
   // Whether the backend should support version-compatible TensorRT models.
   static inline bool is_version_compatible_{false};
+
+  nvinfer1::ExecutionContextAllocationStrategy exec_alloc_strategy_ = nvinfer1::ExecutionContextAllocationStrategy::kSTATIC;
 };
 
 


### PR DESCRIPTION
The changes in the PR support 2 main items:

1. the GPU memory is allocated based on the selected TensorRT profile and not based on the profile that consumes max memory even when it's not selected.
2. Avoid the creation of profile 0 execution context if it's required. 