### PR TITLE
ci: Fix shape tensor segfault

### DIFF
--- a/src/instance_state.cc
+++ b/src/instance_state.cc
@@ -3095,21 +3095,21 @@ ModelInstanceState::InitializeShapeInputBinding(
                                    : context.max_dims_[io_index].d[0];
     context.max_shapes_[io_index] = ShapeTensor();
     context.max_shapes_[io_index].SetDataFromShapeValues(
-        engine_->getProfileTensorValues(
+        engine_->getProfileTensorValuesV2(
             input_name.c_str(), profile_index,
             nvinfer1::OptProfileSelector::kMAX),
         input_datatype, context.nb_shape_values_);
 
     context.min_shapes_[io_index] = ShapeTensor();
     context.min_shapes_[io_index].SetDataFromShapeValues(
-        engine_->getProfileTensorValues(
+        engine_->getProfileTensorValuesV2(
             input_name.c_str(), profile_index,
             nvinfer1::OptProfileSelector::kMIN),
         input_datatype, context.nb_shape_values_);
 
     context.opt_shapes_[io_index] = ShapeTensor();
     context.opt_shapes_[io_index].SetDataFromShapeValues(
-        engine_->getProfileTensorValues(
+        engine_->getProfileTensorValuesV2(
             input_name.c_str(), profile_index,
             nvinfer1::OptProfileSelector::kOPT),
         input_datatype, context.nb_shape_values_);

--- a/src/model_state.cc
+++ b/src/model_state.cc
@@ -708,7 +708,7 @@ ModelState::GetProfileMaxBatchSize(
         }
 
       } else {
-        const int32_t* max_shapes = engine->getProfileTensorValues(
+        const int64_t* max_shapes = engine->getProfileTensorValuesV2(
             tensor_name.c_str(), profile_index,
             nvinfer1::OptProfileSelector::kMAX);
         if (*max_batch_size > *max_shapes) {

--- a/src/shape_tensor.cc
+++ b/src/shape_tensor.cc
@@ -88,7 +88,7 @@ ShapeTensor::SetDataFromBuffer(
 
 TRITONSERVER_Error*
 ShapeTensor::SetDataFromShapeValues(
-    const int32_t* shape_values, TRITONSERVER_DataType datatype,
+    const int64_t* shape_values, TRITONSERVER_DataType datatype,
     size_t nb_shape_values)
 {
   nb_shape_values_ = nb_shape_values;

--- a/src/shape_tensor.h
+++ b/src/shape_tensor.h
@@ -51,7 +51,7 @@ class ShapeTensor {
       const char* input_name, bool support_batching, size_t total_batch_size);
 
   TRITONSERVER_Error* SetDataFromShapeValues(
-      const int32_t* shape_values, TRITONSERVER_DataType datatype,
+      const int64_t* shape_values, TRITONSERVER_DataType datatype,
       size_t nb_shape_values);
 
   int64_t GetDistance(const ShapeTensor& other, int64_t total_batch_size) const;


### PR DESCRIPTION
TRT 10.11.0 Release note: https://docs.nvidia.com/deeplearning/tensorrt/10.11.0/getting-started/release-notes.html
> Deprecated the int32_t version of the profile shape API, including: setShapeValues, getShapeValues, and getProfileTensorValues. We recommend you use version 2 instead.

Segfault is caused by `getProfileTensorValues` returns unexpected nullptr for shape tensors ([relevant lines](https://github.com/triton-inference-server/tensorrt_backend/blob/9d7ba1d5fa76ed958db9430b1dc435d485505a97/src/model_state.cc#L711-L714)). Updating `getProfileTensorValues` to `getProfileTensorValuesV2` fixed the segfault.