### PR TITLE
ci: Update SetDataFromShapeValues implementation after changing shape_values type

### DIFF
--- a/src/shape_tensor.cc
+++ b/src/shape_tensor.cc
@@ -99,14 +99,14 @@ ShapeTensor::SetDataFromShapeValues(
     datatype_ = ShapeTensorDataType::INT32;
     data_.reset(new char[size_]);
     int32_t* data_ptr = reinterpret_cast<int32_t*>(data_.get());
-    std::memcpy(data_ptr, shape_values, size_);
+    for (size_t i = 0; i < nb_shape_values_; ++i) {
+      data_ptr[i] = static_cast<int32_t>(shape_values[i]);
+    }
   } else if (datatype == TRITONSERVER_DataType::TRITONSERVER_TYPE_INT64) {
     datatype_ = ShapeTensorDataType::INT64;
     data_.reset(new char[size_]);
     int64_t* data_ptr = reinterpret_cast<int64_t*>(data_.get());
-    for (size_t i = 0; i < nb_shape_values_; ++i) {
-      data_ptr[i] = static_cast<int64_t>(shape_values[i]);
-    }
+    std::memcpy(data_ptr, shape_values, size_);
   } else {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/shape_tensor.h
+++ b/src/shape_tensor.h
@@ -1,4 +1,4 @@
-// Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
Fix patch for https://github.com/triton-inference-server/tensorrt_backend/pull/112
Fixes
- L0_trt_shape_tensors_shm--TensorRT
- L0_trt_shape_tensors--TensorRT

Pipeline: 30288199