### PR TITLE
build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(TRITON_TENSORRT_BACKEND_INSTALLDIR ${CMAKE_INSTALL_PREFIX}/backends/tensorrt
 if(LINUX)
   file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
   if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
+    set(OPENSSL_ROOT_DIR "/usr/lib64/openssl3")
+    set(OPENSSL_INCLUDE_DIR "/usr/include/openssl3")
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
       set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "/usr/local/cuda/targets/sbsa-linux/lib")
     else()


### PR DESCRIPTION
## Description
Updates CMake so OpenSSL 3 library paths are set on RHEL-like Linux for manylinux/repack builds. Cross-repo change; related PRs are listed below.

## Changes
- 5eb3923 build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

## Affected Files
- CMakeLists.txt

#### Related PRs (other repositories)
- triton-inference-server/server#8731
- triton-inference-server/core#488
- triton-inference-server/client#886
- triton-inference-server/third_party#73
- triton-inference-server/python_backend#434
- triton-inference-server/pytorch_backend#186

#### Test plan
- Confirm CI for this repository completes successfully.
- CI Pipeline ID: (fill when available)

#### Related Issues
- Resolves Linear issue: TRI-938
